### PR TITLE
Add a plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,19 @@
+name: rubygems-oidc
+description: Exchange a Buildkite OIDC token with rubygems.org via an OIDC API Key Role, to securely push Rubygems from your Buildkite pipelines 
+author: https://github.com/buildkite-plugins
+public: true
+requirements:
+  - bash
+  - jq
+configuration:
+  properties:
+    role:
+      type: string
+    host:
+      type: string
+    audience:
+      type: string
+    lifetime:
+      type: string
+  required:
+    - role


### PR DESCRIPTION
I wondered why this plugin wasn't automatically picked up by our directory (https://buildkite.com/resources/plugins/) and then I remembered we have docs that describe how that works (https://buildkite.com/docs/pipelines/integrations/plugins/directory).

I needed to add the `buildkite-plugin` repository topic on Github, and add a plugin.yml to the repository root