### PR TITLE
remove prefixed `=` from the rubygems API key

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -48,7 +48,7 @@ if ! jq -e . >/dev/null 2>&1 <<<"${RESPONSE}"; then
 fi
 
 ERROR_MESSAGE=$(echo "${RESPONSE}" | jq -r .error)
-GEM_HOST_API_KEY==$(echo "${RESPONSE}" | jq -r .rubygems_api_key)
+GEM_HOST_API_KEY=$(echo "${RESPONSE}" | jq -r .rubygems_api_key)
 
 if [ "${ERROR_MESSAGE}" != "null" ]; then
   echo "Requesting API token failed"


### PR DESCRIPTION
While doing some additional testing with this plugin I found a bug 🤦

This double equals was assinging a value of `=<api key>` to the GEM_HOST_API_KEY env var. The gem cli was detecting the env var and using it, but then the API calls fail with an auth error