### PR TITLE
Hard code audience to rubygems.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ The hostname to use when requesting a temporary API token from rubygems. Default
 
 Example: `https://example.com`
 
-### `audience` (optional, string)
-
-The audience to use when requesting an OIDC token from Buildkite. Defaults to `https://rubygems.org` and typically won't need to be customised.
-
-Example: `example.com`
-
 ### `lifetime` (optional, string)
 
 The number of seconds the requested Buildkite OIDC token will be valid for. Defaults to 60 seconds.

--- a/hooks/environment
+++ b/hooks/environment
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+AUDIENCE="rubygems.org"
+
 if [ -z "${RUBYGEMS_HOST:-}" ]; then
   RUBYGEMS_HOST="https://rubygems.org"
 fi
@@ -17,12 +19,6 @@ fi
 
 HOST="${BUILDKITE_PLUGIN_RUBYGEMS_OIDC_HOST}"
 ROLE="${BUILDKITE_PLUGIN_RUBYGEMS_OIDC_ROLE}"
-
-if [ -z "${BUILDKITE_PLUGIN_RUBYGEMS_OIDC_AUDIENCE:-}" ]; then
-  AUDIENCE="${HOST}"
-else
-  AUDIENCE="${BUILDKITE_PLUGIN_RUBYGEMS_OIDC_AUDIENCE}"
-fi
 
 if [ -z "${BUILDKITE_PLUGIN_RUBYGEMS_OIDC_LIFETIME:-}" ]; then
   LIFETIME="60"

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,8 +11,6 @@ configuration:
       type: string
     host:
       type: string
-    audience:
-      type: string
     lifetime:
       type: string
   required:


### PR DESCRIPTION
It was previously https://rubygems.org, and also configurable via parameters.

When creating an API Key Role on rubygems.org, it defaults the rules to requiring an `aud` claim with the value `rubygems.org`. By stripping the `https://` from our default, documenting the process for using this plugin can have one less step.

It also seems unnecessary to keep in configurable. This plugin is specifically for rubygems.org integration, and I can't imagine scenarios where we'd need a different audience on the OIDC tokens.